### PR TITLE
fix JS snags

### DIFF
--- a/actors.js
+++ b/actors.js
@@ -1,14 +1,15 @@
-const regression = require('d3-regression@1');
+import * as regression from 'https://cdn.skypack.dev/d3-regression';
+import * as d3 from 'https://cdn.skypack.dev/d3';
 
-export function plotActors(actors) {
-  
+export function plotActors(actors, talentWeight, looksWeight, minimum) {
+    
   actors = transpose(actors).map(v => ({
     talent: v.x,
     looks: v.y,
     fame: v.x * talentWeight + v.y * looksWeight
   }));
 
-  const w = 700
+  const w = 700;
   const h = 500;
   const result = d3.create("svg").attr("width", w).attr("height", h);
   const margin = 20;

--- a/ojs.qmd
+++ b/ojs.qmd
@@ -21,6 +21,6 @@ viewof minimum = Inputs.range([-2, 2], { value: 1, step: 0.01, label: "min fame"
 
 ```{ojs}
 //| panel: fill
-import { plotActors } from './actors.js'
-plotActors(actors)
+import { plotActors } from './actors.js';
+plotActors(actors, talentWeight, looksWeight, minimum)
 ```


### PR DESCRIPTION
These are annoying differences between the "observable javascript" and actual factual JS. It's unfortunate because I think they're bound to bite quarto users as well. We should probably come up with a plan for how to deal with them. I have some ideas but they're not great. In any case, with this I get an awesome quarto interactive slide:

![image](https://user-images.githubusercontent.com/285675/143929656-a17bb523-2cbe-4d66-99fe-246c482050ed.png)
